### PR TITLE
Extend docker cluster with backend api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 .LSOverride
 .idea
 
+# envs
+.env
+
 # Icon must end with two \r
 Icon
 

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -20,6 +20,22 @@ services:
     volumes:
       - ./mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh:ro
       - db-data:/data/db
+  apiServer:
+    image: node:18-alpine
+    container_name: apiBackendServer
+    restart: always
+    env_file:
+      - .env
+    working_dir: /app
+    environment:
+      API_PORT: ${API_PORT}
+    ports:
+      - ${API_PORT}:${API_PORT}
+    networks:
+      - mongodb-network
+    command: sh -c "npm install && npm run start:dev"
+    volumes:
+      - ./:/app
 volumes:
   db-data:
     driver: local

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,7 +35,6 @@
         "eslint-config-prettier": "^9.0.0",
         "express": "^4.18.2",
         "fill-range": "^7.0.1",
-        "fsevents": "^2.3.3",
         "glob-parent": "^5.1.2",
         "has-flag": "^3.0.0",
         "husky": "^8.0.3",
@@ -1598,6 +1597,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
+      "optional": true,
       "os": [
         "darwin"
       ],

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,6 @@
     "eslint-config-prettier": "^9.0.0",
     "express": "^4.18.2",
     "fill-range": "^7.0.1",
-    "fsevents": "^2.3.3",
     "glob-parent": "^5.1.2",
     "has-flag": "^3.0.0",
     "husky": "^8.0.3",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     networks:
       - mongodb-network
     volumes:
-      - ./mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh:ro
+      - ./backend/mongo-init.sh:/docker-entrypoint-initdb.d/backend/mongo-init.sh:ro
       - db-data:/data/db
   apiServer:
     image: node:18-alpine
@@ -26,7 +26,7 @@ services:
     restart: always
     env_file:
       - .env
-    working_dir: /app
+    working_dir: /app/backend
     environment:
       API_PORT: ${API_PORT}
     ports:
@@ -35,7 +35,7 @@ services:
       - mongodb-network
     command: sh -c "npm install && npm run start:dev"
     volumes:
-      - ./:/app
+      - ./backend:/app/backend
 volumes:
   db-data:
     driver: local


### PR DESCRIPTION
This PR includes:
- add to `docker-compose.yaml` definition of container which run backend api server which connects to mongodb container in cluster network and working as microservices
- add whole backend api to volumes - thanks to this we can develop backend site locally without recomposing this cluster